### PR TITLE
Remove update listeners when tech is disposed

### DIFF
--- a/src/js/tech/chromecast.js
+++ b/src/js/tech/chromecast.js
@@ -23,8 +23,19 @@ class Chromecast extends Tech {
         this.apiSession = this.options_.source.apiSession;
         this.receiver = this.apiSession.receiver.friendlyName;
 
-        this.apiMedia.addUpdateListener(::this.onMediaStatusUpdate);
-        this.apiSession.addUpdateListener(::this.onSessionUpdate);
+        let mediaStatusUpdateHandler = ::this.onMediaStatusUpdate;
+        let sessionUpdateHanlder = ::this.onSessionUpdate;
+
+        this.apiMedia.addUpdateListener(mediaStatusUpdateHandler);
+        this.apiSession.addUpdateListener(sessionUpdateHanlder);
+
+        this.on('dispose', () => {
+          this.apiMedia.removeUpdateListener(mediaStatusUpdateHandler);
+          this.apiSession.removeUpdateListener(sessionUpdateHanlder);
+          this.onMediaStatusUpdate()
+          this.onSessionUpdate(false);
+        });
+
         let tracks = this.textTracks();
         if (tracks) {
             let changeHandler = ::this.handleTextTracksChange;


### PR DESCRIPTION
This change prevents the following error from occurring:

```
Uncaught TypeError: Cannot read property 'vdata...' of null
```

The issue is that the updateListeners are added in the constructor, but never removed anywhere. Should the tech be disposed, the updateListener methods will eventually fire and `onSessionUpdate` will get called, which will make a call to `onStopAppSuccess`, which then calls `stopTrackingCurrentTime` and eventually throws an error because there is no longer an associated element for this disposed tech.

To fix, we remove the updateListeners when the tech is disposed and manually call the update handlers to execute any cleanup they may require before being disposed, such as calling `onStopAppSuccess`.

You can see the same problem happening in [this fiddle](https://jsfiddle.net/7c1qxkuz/8/). Just use the button to swap techs and the same error will occur.