### PR TITLE
Include source scss/fonts in npm package for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "index.html",
     "scripts/",
     "src/js/",
+    "src/css/",
+    "src/fonts/",
     "test/"
   ],
   "babel": {


### PR DESCRIPTION
With this change, you can have a `app.scss` in your webpack project and use the following to import the chromecast fonts and css:

```scss
$icon-font-path: '~videojs-chromecast/src/fonts/';
@import "~videojs-chromecast/src/css/videojs-chromecast";
```