### PR TITLE
Fix metadata options not being passed to chromecast

### DIFF
--- a/src/js/component/control-bar/chromecast-button.js
+++ b/src/js/component/control-bar/chromecast-button.js
@@ -134,8 +134,8 @@ class ChromeCastButton extends Button {
 
         mediaInfo = new chrome.cast.media.MediaInfo(source, type);
         mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
-        if (this.options_.metadata) {
-            ref = this.options_.metadata;
+        if (this.options_.playerOptions.chromecast.metadata) {
+            ref = this.options_.playerOptions.chromecast.metadata;
             for (key in ref) {
                 value = ref[key];
                 mediaInfo.metadata[key] = value;


### PR DESCRIPTION
Not sure if this worked before, but it does now.

I didn't run `npm run build` since it'll cause conflicts with other PRs